### PR TITLE
Fix full page plot boundary error

### DIFF
--- a/gemini-app/src/Components/GCP/TabComponents/PlotBoundaryPrep.js
+++ b/gemini-app/src/Components/GCP/TabComponents/PlotBoundaryPrep.js
@@ -94,7 +94,14 @@ function PlotBoundaryPrep() {
         }
         
         // For all other steps, allow normal navigation
-        setActiveStepBoundaryPrep(index);
+        if(index === 2){
+            if(activeStepBoundaryPrep === 1 || activeStepBoundaryPrep === 3){
+                setActiveStepBoundaryPrep(2);
+            }
+        }
+        else {
+            setActiveStepBoundaryPrep(index);
+        }
     };
 
     const isImageViewerOpenRef = useRef(isImageViewerOpen);


### PR DESCRIPTION
- Allow plot boundary tab to be accessed from pop boundary or assign labels / split plot images tabs only
- Prevents full page error when trying to open tab; may be more elegant way to implement